### PR TITLE
fix: adjust bottom padding in LargeMensaCellView

### DIFF
--- a/ethmensa/Views/MainView/MensaCells/LargeMensaCellView.swift
+++ b/ethmensa/Views/MainView/MensaCells/LargeMensaCellView.swift
@@ -70,7 +70,7 @@ struct LargeMensaCellView: View {
             )
             .ignoresSafeArea()
             .frame(height: 50)
-            .padding(.bottom, -11)
+            .padding(.bottom, -15)
             .padding(.leading, -20)
             .padding(.trailing, -40)
             .overlay {


### PR DESCRIPTION
Adjusted padding in the LargeMensaCellView to fix a visual bug of the image leaking below the content field. Tested in the Simulator on various phone sizes, and an iPhone 16. 

Before             |  After
:-------------------------:|:-------------------------:
<img width="1206" height="2622" alt="Before" src="https://github.com/user-attachments/assets/5ec9ea51-8636-4353-9a4e-fe8b3fa79866" />  |  <img width="1206" height="2622" alt="After" src="https://github.com/user-attachments/assets/3ca680bf-1f97-4b5e-a10b-fffac43b5866" />