### PR TITLE
fix: memory crash in image decoding

### DIFF
--- a/ethmensa/AppIntents/MensaEntity.swift
+++ b/ethmensa/AppIntents/MensaEntity.swift
@@ -28,13 +28,12 @@ struct MensaEntity: AppEntity, Identifiable {
     @Property(title: "MENSA_NAME")
     var name: String
 
+    private static let appIconPngData: Data? = UIImage.appIconRoundedForUserVersion.pngData()
+
     var displayRepresentation: DisplayRepresentation {
-        if let uiImagePngData = UIImage(
-            resource: .appIconRoundedForUserVersion
-        ).pngData() {
+        if let uiImagePngData = Self.appIconPngData {
             .init(
                 title: "\(name)",
-                // In the future return image of the Mensa itself, probably from `URLImage` cache
                 image: DisplayRepresentation.Image(
                     data: uiImagePngData
                 )

--- a/ethmensa/Extensions/UIImageExtension.swift
+++ b/ethmensa/Extensions/UIImageExtension.swift
@@ -18,10 +18,6 @@
 import SwiftUI
 
 extension UIImage {
-    static var appIconRoundedForUserVersion: UIImage {
-        .init(resource: .appIconRoundedForUserVersion)
-    }
-    static var appETHVideoIconRoundedForUserVersion: UIImage {
-        .init(resource: .appETHVideoIconRoundedForUserVersion)
-    }
+    static let appIconRoundedForUserVersion: UIImage = .init(resource: .appIconRoundedForUserVersion)
+    static let appETHVideoIconRoundedForUserVersion: UIImage = .init(resource: .appETHVideoIconRoundedForUserVersion)
 }


### PR DESCRIPTION
## Problem Description

The App crashes often due to memory issues. 

### How to replicate? 

1. Open the App
2. Take a screenshot (forces loading) 
3. Wait for 10 seconds
4. App crashes

In case your iOS settings make you use the full screen screenshot ui (iOS 26), you can close that after taking the screenshot to see the app crash. 

 Xcode reports the following

```
The app “ETH Mensa” has been killed by the operating system because it is using too much memory.
Domain: IDEDebugSessionErrorDomain
Failure Reason: Message from debugger: Terminated due to memory issue
Recovery Suggestion: Use a memory profiling tool to track the process memory usage.
```
 
<img width="2052" height="1138" alt="SCR-20260319-sdwp" src="https://github.com/user-attachments/assets/54b7813d-e6f1-444e-bb98-29b5b7719134" />

## The fix

- fix crash caused by UIImage.appIconRoundedForUserVersion being a computed var, every access decoded the full 2048×2048 app icon from the asset catalog
- MensaEntity.displayRepresentation accessed it per entity, causing 88 × 32 MB = 2.75 GiB of VM: CoreUI image data
- changed to static let so the image is decoded once and shared
- cached PNG encoding as static let so it's not re-encoded per entity

<img width="2052" height="1138" alt="SCR-20260319-sdzz" src="https://github.com/user-attachments/assets/65480916-e557-4dbc-8f5e-e595729d0fea" />

## Testing

Still need to do some testing, which is why this is a draft only. Open to comments and thoughts.