### PR TITLE
Fix meal description truncation when image is present

### DIFF
--- a/ethmensa/Views/DetailView/MenuCellView.swift
+++ b/ethmensa/Views/DetailView/MenuCellView.swift
@@ -97,6 +97,7 @@ struct MealCellView: View {
                     }
                     if let description = meal.description {
                         Text(description)
+                            .fixedSize(horizontal: false, vertical: true)
                     }
                 }
                 Spacer()
@@ -120,6 +121,7 @@ struct MealCellView: View {
                         }
                         .scaledToFill()
                         .frame(width: 60, height: 60)
+                        .clipped()
                         .cornerRadius(10)
                     }
                     .buttonStyle(.plain)


### PR DESCRIPTION
## Problem Description

Prevent the meal description in menu cells from being truncated to a single line when an image is present. This keeps the text layout stable in List rows by allowing the description to expand vertically as needed, and clips the preview image to its fixed frame so scaled content does not bleed outside the rounded thumbnail.

## Testing

Tested on iOS and iPadOS in the Simulator and an iPhone. Due to the (minimal) nature of the changes, this is expected to work on all devices. 

## Screenshots

| Before | After |
:-------------------------:|:-------------------------:
| ![FFEE0D71-E0A9-41E3-AE3F-2FAB555930F9_1_105_c](https://github.com/user-attachments/assets/9c5a8de3-520c-4e65-ba8d-f29569fcf65f) | ![066C2791-A08A-424B-B672-76C353401193_1_105_c](https://github.com/user-attachments/assets/be09dfc5-8be6-4857-a96f-4ef4f949135e) |