### PR TITLE
Move ZFV API key into local xcconfig

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ ETH Mensa.doccarchive
 ethmensa.xcodeproj/project.xcworkspace/xcuserdata
 ethmensa.xcodeproj/xcuserdata
 xcschememanagement.plist
+Config/Secrets.xcconfig

--- a/Config/Secrets.example.xcconfig
+++ b/Config/Secrets.example.xcconfig
@@ -1,0 +1,1 @@
+ZFV_API_KEY = key_goes_here

--- a/README.md
+++ b/README.md
@@ -45,7 +45,8 @@ Otherwise, the most actual code documentation can be built in Xcode using DocC.
 ## Installation
 1. Clone the repo: ```git clone https://github.com/alexandrereol/ethmensa.git```
 2. Change the bundle identifier/team identifier/development team in the project settings
-3. Run the app on your device
+3. Copy `Config/Secrets.example.xcconfig` to `Config/Secrets.xcconfig` and set `ZFV_API_KEY`
+4. Run the app on your device
 
 ## Contribute
 If you would like to contribute to the codebase, please fork the repository and submit a pull request.

--- a/ethmensa.xcodeproj/project.pbxproj
+++ b/ethmensa.xcodeproj/project.pbxproj
@@ -84,6 +84,8 @@
 
 /* Begin PBXFileReference section */
 		291C81DB2B5998BB00730BFD /* ETH Mensa visionOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "ETH Mensa visionOS.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		2920D0012F10000100000001 /* Secrets.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Config/Secrets.xcconfig; sourceTree = SOURCE_ROOT; };
+		2920D0012F10000100000002 /* Secrets.example.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Config/Secrets.example.xcconfig; sourceTree = SOURCE_ROOT; };
 		293CAF6E2D6DCFFD0066E9F8 /* .swiftlint.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = .swiftlint.yml; sourceTree = "<group>"; };
 		294E16392A8E22C3000A3AB6 /* ETH Mensa.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "ETH Mensa.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		29550BD32AEADD550014F07F /* ETH Mensa Clip.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "ETH Mensa Clip.app"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -375,9 +377,19 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		2920D0012F10000100000003 /* Config */ = {
+			isa = PBXGroup;
+			children = (
+				2920D0012F10000100000001 /* Secrets.xcconfig */,
+				2920D0012F10000100000002 /* Secrets.example.xcconfig */,
+			);
+			path = Config;
+			sourceTree = "<group>";
+		};
 		294E16302A8E22C3000A3AB6 = {
 			isa = PBXGroup;
 			children = (
+				2920D0012F10000100000003 /* Config */,
 				293CAF6E2D6DCFFD0066E9F8 /* .swiftlint.yml */,
 				290E0D112E0ACFBA005E0BD4 /* ethmensa */,
 				290E09B92E0ACF5C005E0BD4 /* clip */,
@@ -752,6 +764,7 @@
 /* Begin XCBuildConfiguration section */
 		291C81EB2B5998BC00730BFD /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 2920D0012F10000100000001 /* Secrets.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
@@ -782,6 +795,7 @@
 		};
 		291C81EC2B5998BC00730BFD /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 2920D0012F10000100000001 /* Secrets.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
@@ -947,6 +961,7 @@
 		};
 		294E16492A8E22C6000A3AB6 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 2920D0012F10000100000001 /* Secrets.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
@@ -996,6 +1011,7 @@
 		};
 		294E164A2A8E22C6000A3AB6 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 2920D0012F10000100000001 /* Secrets.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;

--- a/ethmensa/App/Info.plist
+++ b/ethmensa/App/Info.plist
@@ -47,5 +47,7 @@
 		<key>UISceneConfigurations</key>
 		<dict/>
 	</dict>
+	<key>ZFV_API_KEY</key>
+	<string>$(ZFV_API_KEY)</string>
 </dict>
 </plist>

--- a/ethmensa/Data/API/ZFV/ZFVGraphQLClient.swift
+++ b/ethmensa/Data/API/ZFV/ZFVGraphQLClient.swift
@@ -20,7 +20,7 @@ import ApolloAPI
 import Foundation
 import os.log
 
-class ZFVGraphQLClient {
+final class ZFVGraphQLClient {
     static let shared = ZFVGraphQLClient()
 
     private let logger = Logger(
@@ -28,10 +28,13 @@ class ZFVGraphQLClient {
         category: String(describing: ZFVGraphQLClient.self)
     )
 
-    private let client: ApolloClient = {
+    private lazy var client: ApolloClient? = {
         let store = ApolloStore()
-        // swiftlint:disable:next line_length
-        let apiKey = "Y205NnFzenc4OGw2bnM2MHQ2MGh6OTlvdTpacE1aTGpUNFAxK1dJM0RmWUNsSXdoS3hXQldXUE5USHhRUmcxUUhZUnZCOWp1N3JadHFxOUZkUXNMdGVmSFI5"
+        guard let apiKey = Bundle.main.zfvAPIKey else {
+            logger.error("Missing ZFV_API_KEY")
+            return nil
+        }
+
         let transport = RequestChainNetworkTransport(
             interceptorProvider: DefaultInterceptorProvider(store: store),
             endpointURL: URL(string: "https://api.zfv.ch/graphql")!,
@@ -44,6 +47,10 @@ class ZFVGraphQLClient {
     }()
 
     func getMensas() async -> ZFVGraph.MensasQuery.Data? {
+        guard let client else {
+            return nil
+        }
+
         do {
             let result = try await client.fetchAsync(
                 query: ZFVGraph.MensasQuery()


### PR DESCRIPTION
Move the ZFV API key out of public source and load it from a local `Secrets.xcconfig` instead.

- `Config/Secrets.xcconfig` in `.gitignore`
- add `Config/Secrets.example.xcconfig` as a setup template
- `ZFV_API_KEY` in `Info.plist`
- read key in `ZFVGraphQLClient` from `Bundle.main`
- quick update in readme